### PR TITLE
Fix unpacking and logging for forecasting

### DIFF
--- a/scripts/market_scanner_live.py
+++ b/scripts/market_scanner_live.py
@@ -73,13 +73,23 @@ def analyze_stock(
         if model_type.lower() in ["rf", "xgb"]:
             # For example, re-use your existing train_random_forest() or train_xgboost() from main.py
             if model_type.lower() == "rf":
-                model, X_test, y_test, predictions, mse_val = train_random_forest(
-                    features, target
-                )
+                (
+                    model,
+                    X_test,
+                    y_test,
+                    predictions,
+                    mse_val,
+                    sharpe_ratio,
+                ) = train_random_forest(features, target)
             else:
-                model, X_test, y_test, predictions, mse_val = train_xgboost(
-                    features, target
-                )
+                (
+                    model,
+                    X_test,
+                    y_test,
+                    predictions,
+                    mse_val,
+                    sharpe_ratio,
+                ) = train_xgboost(features, target)
 
             # Suppose we just do last predictions from X_test
             # (You could do a “forward forecast” if you want.)


### PR DESCRIPTION
## Summary
- fix incorrect unpacking of train functions in `market_scanner_live.py`
- ensure forecasting variables are initialized and computed for all paths in `main.py`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_6840347a77d4832bbeab3ed1227853e9